### PR TITLE
応用02

### DIFF
--- a/src/main/scala/advance/chapter02/Chukyu.scala
+++ b/src/main/scala/advance/chapter02/Chukyu.scala
@@ -1,0 +1,9 @@
+package com.github.trackiss
+package advance.chapter02
+
+object Chukyu {
+  class Container[+A](n: A) {
+    def put[E >: A](a: E): Container[E] = new Container(a)
+    def get(): A = n
+  }
+}

--- a/src/main/scala/advance/chapter02/Jokyu.scala
+++ b/src/main/scala/advance/chapter02/Jokyu.scala
@@ -1,0 +1,18 @@
+package com.github.trackiss
+package advance.chapter02
+
+object Jokyu {
+  def y[A, B](f: (A => B, A) => B, a: A): B = f((yy: A) => y(f, yy), a)
+
+  def isSorted[E](sortedSeq: Seq[E])(ordered: (E, E) => Boolean): Boolean =
+    if (sortedSeq.isEmpty) true
+    else
+      y(
+        (f: Int => Boolean, n: Int) => {
+          if (n == sortedSeq.length - 1) true
+          else if (!ordered(sortedSeq(n), sortedSeq(n + 1))) false
+          else f(n + 1)
+        },
+        0
+      )
+}

--- a/src/main/scala/advance/chapter02/Shokyu.scala
+++ b/src/main/scala/advance/chapter02/Shokyu.scala
@@ -1,0 +1,6 @@
+package com.github.trackiss
+package advance.chapter02
+
+object Shokyu {
+  case class Pair[A, B](a: A, b: B)
+}


### PR DESCRIPTION
## やったこと

初級: 型パラメーター
中級: 共変・下限境界
上級: カリー化と型推論

## 学んだこと

- public でミュータブルなフィールドを持つクラスは共変/反変にすることができない
- 共変な型パラメーターはパラメーターの型に使うことができず、反変な型パラメーターは返り値の型に使うことができない
    - それぞれ、C# でいう `out` パラメーターと `in` パラメーターに相当すると理解した。in は非破壊なので下限境界の考え方は不要だけど
    - https://qiita.com/mtoyoshi/items/bd0ad545935225419327 ここ読んだ方がはるかにわかりやすい
- パラメーターに無名関数を受け取る多相関数があったとき、無名関数の型が前の別の引数に依存する場合 (ex: `def Foo[A](a: A)(f: A => A): A = ???`) は、カリー化させることで型推論できるようになる
    - Scala 3の型推論器「われわれはかしこいので」
        - Scala 3 ではカリー化しなくても型推論してくれるらしい
- Y コンビネーター、いいね
    - でもこれ末尾再帰最適化されないよね？ どうすんだろ