### PR TITLE
応用04

### DIFF
--- a/src/main/scala/advance/chapter04/Chukyu.scala
+++ b/src/main/scala/advance/chapter04/Chukyu.scala
@@ -1,0 +1,24 @@
+package com.github.trackiss
+package advance.chapter04
+
+object Chukyu {
+  sealed trait Result
+  case class Point(point: Int) extends Result
+
+  sealed trait Error extends Result
+  case object StudentNotFound extends Error
+  case object ResultNotFound extends Error
+
+  private[this] val results = Map(
+    "taro" -> Some(90),
+    "jiro" -> None
+  )
+
+  def find(name: String): Result = {
+    for {
+      pointOpt <- (results get name) toRight StudentNotFound
+      point <- pointOpt toRight ResultNotFound
+    } yield Point(point)
+  }.merge
+
+}

--- a/src/main/scala/advance/chapter04/Jokyu.scala
+++ b/src/main/scala/advance/chapter04/Jokyu.scala
@@ -1,0 +1,20 @@
+package com.github.trackiss
+package advance.chapter04
+
+object Jokyu {
+  sealed trait Either[+E, +A] {
+    def map[B](f: A => B): Either[E, B] = this match {
+      case Right(v) => Right(f(v))
+      case Left(e)  => Left(e)
+    }
+
+    def flatMap[EE >: E, B](f: A => Either[EE, B]): Either[EE, B] = this match {
+      case Right(v) => f(v)
+      case Left(e)  => Left(e)
+    }
+  }
+
+  case class Left[+E](get: E) extends Either[E, Nothing]
+
+  case class Right[+A](get: A) extends Either[Nothing, A]
+}

--- a/src/main/scala/advance/chapter04/Shokyu.scala
+++ b/src/main/scala/advance/chapter04/Shokyu.scala
@@ -1,0 +1,11 @@
+package com.github.trackiss
+package advance.chapter04
+
+import scala.util.Try
+
+object Shokyu {
+  def createString(size: Int): Try[String] = Try {
+    require(size >= 0, "sizeはゼロ以上である必要があります")
+    ((0 until size) map (_ => "a")).mkString
+  }
+}


### PR DESCRIPTION
## やったこと

初級: Try を使う
中級: Either を使う
上級: Either を作る

## 学んだこと

- 昔 (Scala 2.11 以前) は Either にバイアスかかってなかったんやな… 大変そう
    - 今は right biased になっているので、map も flatmap もある
- merge は、Either[A, A] をこねこねして A にしてくれるらしい。イケメン

## 所感？

- 初級の `(for (i <- 0 to size) yield "a").mkString` っていう書き方が気持ち悪かった
    - せめてアンダースコアで廃棄してほしい
- というか、そもそも `0 to size` ではなくて `0 until size` じゃないか？ `createString(0)` で `Success(a)` になるのおかしいよね
    - これは運営に問い合わせるべきか
