### PR TITLE
応用05

### DIFF
--- a/src/main/scala/advance/chapter05/Chukyu.scala
+++ b/src/main/scala/advance/chapter05/Chukyu.scala
@@ -1,0 +1,26 @@
+package com.github.trackiss
+package advance.chapter05
+
+object Chukyu {
+  def foo(): Unit = {
+    val l: List[Int] = (0 until 10000000).toList
+    val a: Array[Int] = (0 until 10000000).toArray
+
+    benchmark {
+      val _ = l(9999999)
+    }
+
+    benchmark {
+      val _ = a(9999999)
+    }
+  }
+
+  def benchmark(f: => Unit): Unit = {
+    val begin = System.nanoTime()
+    f
+    val end = System.nanoTime()
+
+    val formatter = java.text.NumberFormat.getNumberInstance()
+    println(s"time: ${formatter.format(end - begin)} ナノ秒")
+  }
+}

--- a/src/main/scala/advance/chapter05/Jokyu.scala
+++ b/src/main/scala/advance/chapter05/Jokyu.scala
@@ -1,0 +1,42 @@
+package com.github.trackiss
+package advance.chapter05
+
+import scala.collection.immutable.{HashMap, TreeMap}
+
+object Jokyu {
+  def foo(): Unit = {
+    var a: Array[Int] = Array.empty
+    var hm: HashMap[Int, Int] = HashMap.empty
+    var tm: TreeMap[Int, Int] = TreeMap.empty
+
+    benchmark {
+      a = (0 until 100000).toArray
+    }
+    benchmark {
+      val _ = a(99999)
+    }
+
+    benchmark {
+      hm = HashMap((0 until 100000) map (x => x -> x): _*)
+    }
+    benchmark {
+      val _ = hm(99999)
+    }
+
+    benchmark {
+      tm = TreeMap((0 until 100000) map (x => x -> x): _*)
+    }
+    benchmark {
+      val _ = tm(99999)
+    }
+  }
+
+  def benchmark(f: => Unit): Unit = {
+    val begin = System.nanoTime()
+    f
+    val end = System.nanoTime()
+
+    val formatter = java.text.NumberFormat.getNumberInstance()
+    println(s"time: ${formatter.format(end - begin)} ナノ秒")
+  }
+}

--- a/src/main/scala/advance/chapter05/Shokyu.scala
+++ b/src/main/scala/advance/chapter05/Shokyu.scala
@@ -1,0 +1,36 @@
+package com.github.trackiss
+package advance.chapter05
+
+object Shokyu {
+  def foo(): Unit = {
+    var l1: List[Int] = List.empty
+    var a1: Array[Int] = Array.empty
+    var l2: List[Int] = List.empty
+    var a2: Array[Int] = Array.empty
+
+    benchmark {
+      (0 to 10000) foreach (x => l1 = l1 :+ x)
+    }
+
+    benchmark {
+      (0 to 10000) foreach (x => a1 = a1 :+ x)
+    }
+
+    benchmark {
+      (0 to 10000) foreach (x => l2 = x +: l2)
+    }
+
+    benchmark {
+      (0 to 10000) foreach (x => a2 = x +: a2)
+    }
+  }
+
+  def benchmark(f: => Unit): Unit = {
+    val begin = System.currentTimeMillis()
+    f
+    val end = System.currentTimeMillis()
+
+    val formatter = java.text.NumberFormat.getNumberInstance()
+    println(s"time: ${formatter.format(end - begin)} ミリ秒")
+  }
+}


### PR DESCRIPTION
## やったこと

初級: リストと配列のパフォーマンス (参照)
中級: リストと配列のパフォーマンス (生成)
上級: より高機能なコレクションのパフォーマンス

## 学んだこと

- Set と Map は、要素数5つまでに関してはそれぞれ個別の実装が用意されている
- `foo(xs: _*)` とやることで、Seq の各要素を取り出して可変長引数として展開してくれるらしい。普通に知らなかった

## 所感？

上級に関しては、なぜか配列の参照が一番遅いというまったく異なる結果になった。
HashMap および TreeMap が大幅に性能向上したのかと思いきや、数字を見た限りでは単に配列の参照だけがとびぬけて遅くなってしまっているっぽい。なぜ？