### PR TITLE
応用07

### DIFF
--- a/src/main/scala/advance/chapter07/ChukyuAndJokyu.scala
+++ b/src/main/scala/advance/chapter07/ChukyuAndJokyu.scala
@@ -1,0 +1,31 @@
+package com.github.trackiss
+package advance.chapter07
+
+object ChukyuAndJokyu {
+  sealed trait LazyList[+A] {
+    def headOption: Option[A] = this match {
+      case Cons(h, _)    => Some(h())
+      case EmptyLazyList => None
+    }
+
+    def tail: LazyList[A] = this match {
+      case Cons(_, t)    => t()
+      case EmptyLazyList => throw new Exception()
+    }
+  }
+
+  case object EmptyLazyList extends LazyList[Nothing]
+
+  case class Cons[+A](h: () => A, t: () => LazyList[A]) extends LazyList[A]
+
+  object LazyList {
+    def cons[A](h: => A, t: => LazyList[A]): LazyList[A] = {
+      lazy val hh = h
+      lazy val tt = t
+
+      Cons(() => hh, () => tt)
+    }
+
+    def empty[A]: LazyList[A] = EmptyLazyList
+  }
+}

--- a/src/main/scala/advance/chapter07/Shokyu.scala
+++ b/src/main/scala/advance/chapter07/Shokyu.scala
@@ -1,0 +1,9 @@
+package com.github.trackiss
+package advance.chapter07
+
+object Shokyu {
+  val tribs: LazyList[Int] =
+    0 #:: 0 #:: 1 #:: ((tribs lazyZip tribs.tail lazyZip tribs.tail.tail) map (
+      (a, b, c) => a + b + c
+    ))
+}


### PR DESCRIPTION
## やったこと

初級: LazyList でトリボナッチ配列生成
中級: LazyList の実装
上級: 再評価されない LazyList の実装 (中級の時点で達成できていたため省略)

## 学んだこと

- Stream は 2.13 以降 非推奨となっており、かわりに LazyList を使う
    - 最初の要素も遅延評価されるようになったらしい。あと Java の Stream との差別化だろうか
- 初級のやり方 (タプルの添字アクセス) が気に入らず、transpose でいいんじゃないかと思ったけど、強制的に全要素が評価されてしまうとのこと
    - `for { l1 <- tribs l2 <- tribs.tail l3 <- tribs.tail.tail } yield l1 + l2 + l3` みたいにやってもダメだった
    - lazyZip で対処
- あとで Wartremover に怒られた (#9) ため、`tribs.tail` ではなく `tribs drop 1` に変更
    - ↓の所感でも少し気になってはいたが、tail だと要素がなかったときに例外を投げてしまう。しかし drop(1) なら空のコレクションが返ってくる

## 所感？

- Q. 中級、なんで tail のほうは Option にしなかったの？
    - A. 公式の実装でもそうだったから？
- コレクションのメソッド、「そういうのもあるのか」みたいなやつが非常に多いため、暇なときに API ドキュメントを読み漁りたい