### PR TITLE
応用13

### DIFF
--- a/.idea/scala_compiler.xml
+++ b/.idea/scala_compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaCompilerConfiguration">
-    <profile name="sbt 1" modules="my-parser,n-school-scala">
+    <profile name="sbt 1" modules="n-school-scala">
       <option name="macros" value="true" />
       <parameters>
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.AnyVal" />
@@ -26,11 +26,8 @@
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.Null" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.Option2Iterable" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.OptionPartial" />
-        <parameter value="-P:wartremover:traverser:org.wartremover.warts.PlatformDefault" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.PublicInference" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.Return" />
-        <parameter value="-P:wartremover:traverser:org.wartremover.warts.StringPlusAny" />
-        <parameter value="-P:wartremover:traverser:org.wartremover.warts.ToString" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.TraversableOps" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.TryPartial" />
         <parameter value="-P:wartremover:traverser:org.wartremover.warts.While" />

--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,13 @@ lazy val globalSettings = Seq(
     Wart.JavaSerializable,
     Wart.ListAppend,
     Wart.Overloading,
+    Wart.PlatformDefault,
     Wart.Product,
     Wart.Recursion,
     Wart.Serializable,
+    Wart.StringPlusAny,
     Wart.Throw,
+    Wart.ToString,
     Wart.Var
   )
 )

--- a/chatbot.txt
+++ b/chatbot.txt
@@ -1,0 +1,15 @@
+(chatbot
+    (time "time" 5 12 "Asia/Tokyo" (
+        "早起きだね"
+        "おはよう"
+    ))
+    (reply "reply" (
+        "こんにちは"
+        "よろしくね"
+    ))
+    (set-values (
+        (1: "Apple")
+        (2: "Orange")
+        (3: "Grape")
+    ))
+)

--- a/src/main/scala/advance/chapter13/ChatBot.scala
+++ b/src/main/scala/advance/chapter13/ChatBot.scala
@@ -1,0 +1,4 @@
+package com.github.trackiss
+package advance.chapter13
+
+final case class ChatBot(commands: List[Command])

--- a/src/main/scala/advance/chapter13/ChatBotMain.scala
+++ b/src/main/scala/advance/chapter13/ChatBotMain.scala
@@ -1,0 +1,52 @@
+package com.github.trackiss
+package advance.chapter13
+
+import scala.annotation.tailrec
+import scala.io.Source
+import scala.io.StdIn
+import scala.util.Using
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.PublicInference",
+    "org.wartremover.warts.StringPlusAny"
+  )
+)
+object ChatBotMain extends App {
+  locally {
+    val _ = Using(Source.fromFile("./chatbot.txt")) { source =>
+      val text = source.mkString
+
+      val chatBot = ChatBotTextParser(text) match {
+        case ChatBotTextParser.Success(result, _) => result
+        case _: ChatBotTextParser.NoSuccess       => scala.sys.error("parse error")
+      }
+
+      println(s"chatBot: $chatBot")
+      println("ChatBot booted.")
+
+      @tailrec
+      def checkInput(): Unit = {
+        val input: String = StdIn.readLine(">> ") match {
+          case "exit" => System.exit(0); ???
+          case t @ _  => t
+        }
+
+        @tailrec
+        def execute(input: String, commands: List[Command]): Unit = {
+          if (
+            commands.nonEmpty && !((commands.headOption getOrElse (throw new Exception)) exec input)
+          ) {
+            execute(input, commands drop 1)
+          }
+        }
+
+        execute(input, chatBot.commands)
+        checkInput()
+      }
+
+      checkInput()
+    }
+  }
+
+}

--- a/src/main/scala/advance/chapter13/ChatBotTextParser.scala
+++ b/src/main/scala/advance/chapter13/ChatBotTextParser.scala
@@ -1,0 +1,52 @@
+package com.github.trackiss
+package advance.chapter13
+
+import scala.util.parsing.combinator.JavaTokenParsers
+
+object ChatBotTextParser extends JavaTokenParsers {
+  def chatBot: Parser[ChatBot] =
+    "(" ~ "chatbot" ~ commandList ~ ")" ^^ { case _ ~ _ ~ cs ~ _ =>
+      ChatBot(cs)
+    }
+
+  def commandList: Parser[List[Command]] = rep(command)
+
+  def command: Parser[Command] = replyCommand | timeCommand | setValuesCommand
+
+  def replyCommand: Parser[ReplyCommand] =
+    "(" ~ "reply" ~ string ~ replyList ~ ")" ^^ { case _ ~ _ ~ s ~ rs ~ _ =>
+      ReplyCommand(s.r, rs)
+    }
+
+  def setValuesCommand: Parser[GetValueCommand] =
+    "(" ~ "set-values" ~ replyListWithIndex ~ ")" ^^ { case _ ~ _ ~ is ~ _ =>
+      GetValueCommand(is.toMap)
+    }
+
+  def replyList: Parser[List[String]] =
+    "(" ~ rep(string) ~ ")" ^^ { case _ ~ ss ~ _ => ss }
+
+  def replyListWithIndex: Parser[List[(Int, String)]] =
+    "(" ~ rep(digitAndStringPair) ~ ")" ^^ { case _ ~ ds ~ _ => ds }
+
+  def timeCommand: Parser[TimeCommand] =
+    "(" ~ "time" ~ string ~ digits ~ digits ~ string ~ replyList ~ ")" ^^ {
+      case _ ~ _ ~ r ~ s ~ e ~ z ~ rs ~ _ =>
+        TimeCommand(r.r, s.toInt, e.toInt, z, rs)
+    }
+
+  def digits: Parser[String] = """[0-9]+""".r
+
+  def string: Parser[String] = stringLiteral ^^ { s =>
+    s.substring(1, s.length - 1)
+  }
+
+  def digitAndStringPair: Parser[(Int, String)] =
+    "(" ~ digits ~ ":" ~ string ~ ")" ^^ { case _ ~ d ~ _ ~ s ~ _ =>
+      (d.toInt, s)
+    }
+
+  def hand: Parser[String] = "rock" | "paper" | "scissor"
+
+  def apply(input: String): ParseResult[ChatBot] = parseAll(chatBot, input)
+}

--- a/src/main/scala/advance/chapter13/Command.scala
+++ b/src/main/scala/advance/chapter13/Command.scala
@@ -1,0 +1,53 @@
+package com.github.trackiss
+package advance.chapter13
+
+import java.time.{LocalDateTime, ZoneId}
+import scala.util.Random
+import scala.util.Random.shuffle
+import scala.util.matching.Regex
+
+sealed trait Command {
+  def exec(input: String): Boolean
+}
+
+final case class ReplyCommand(regex: Regex, replies: List[String])
+    extends Command {
+  override def exec(input: String): Boolean = regex findFirstIn input match {
+    case Some(_) =>
+      shuffle(replies).headOption foreach println
+      true
+    case None => false
+  }
+}
+
+final case class TimeCommand(
+    regex: Regex,
+    start: Int,
+    end: Int,
+    zone: String,
+    replies: List[String]
+) extends Command {
+  override def exec(input: String): Boolean = {
+    val now = LocalDateTime.now() atZone ZoneId.of(zone)
+    val isInTime = start <= now.getHour && now.getHour <= end
+    regex findFirstIn input match {
+      case Some(_) if isInTime =>
+        shuffle(replies).headOption foreach println
+        true
+      case _ => false
+    }
+  }
+}
+
+final case class GetValueCommand(indexAndStrings: Map[Int, String])
+    extends Command {
+  override def exec(input: String): Boolean =
+    if (input startsWith "get-value")
+      (input drop 9).trim.toIntOption match {
+        case Some(v) =>
+          println(indexAndStrings.getOrElse(v, "not found"))
+          true
+        case None => false
+      }
+    else false
+}


### PR DESCRIPTION
## やったこと

初級: DSL を探せ

- [Akka HTTP](https://github.com/akka/akka-http) の Routing DSL
- [better-files](https://github.com/pathikrit/better-files) の UNIX DSL
    - これおもしろいね
- [Scalatex](https://github.com/lihaoyi/Scalatex)
- [ScalaTags](https://com-lihaoyi.github.io/scalatags/)

中級: ChatBot の拡張 (配列 (というか `Map[Int, String]`) を保持しておき、あとから取り出せる機能を追加)

上級: DSL の作成 (未実施。中級のしょうもないケアレスミスで時間くったため。また時間あるときに目一杯やる)

## 学んだこと

- コードは完璧だったのに、chatbot.txt の内容が間違っていたせいで1、2時間くらい時間とられた。ちゃんと見直そうね
- Scala 2.13 以降は `Using` を使うことでローンパターンが実現できる。C# のアレだ
- `System.exit()` は Unit 型。Nothing にしてくれれば多少はマシに書けるのに...
    - `val str = readLine(); if (str == "exit") System.exit(0)` みたいな else のない手続き的 if は使いたくないので、match で書く
    - -> でも `System.exit(Int)` は Unit 型なので型が一致しない
    - -> しかたなく `val str = readLine() match case "exit" => System.exit(Int); ??? case s @ _ => s` って書いた。きもっ
- N 予備校のコードは平気で添字アクセスをしてくるので気持ち悪い
    - パフォーマンス的には確実に添字に劣るだろうけど、パターンマッチングで `case _ ~ s ~ _ ~ _ => s` みたいに書いたほうがマシ
    - `String ~ String ~ String ~ String` 型は、タプル的には `(((String, String), String), String)` という扱いになっているらしい。つまり左から2番目の値を取り出したいなら `t._1._1._2` で持ってこられる
    - タプルの添字がアンダースコアついてたり、0でなく1始まりだったり、とてつもなく気持ち悪い感じになってるのはなるべく添字アクセスをしてほしくないからだった...？
- 純正のパーサーコンビネーターより [FastParse](https://com-lihaoyi.github.io/fastparse/) のほうが使いやすいかもしれん
    - やっぱり Li Haoyi 氏すごいよね

## 所感？

- ようやく慣れてきた
    - これは TDBot に使えるぞ