### PR TITLE
並行処理09

### DIFF
--- a/concurrent/src/main/scala/chapter09/Jokyu.scala
+++ b/concurrent/src/main/scala/chapter09/Jokyu.scala
@@ -1,0 +1,83 @@
+package com.github.trackiss
+package chapter09
+
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+
+import scala.math.ceil
+
+object Jokyu {
+  final case class Task(numbers: Seq[Int], sender: ActorRef[Result])
+  final case class Result(countPrimeNumber: Int)
+
+  object MainActor {
+    private def splitRange(range: Range, divideBy: Int): Seq[Range] = {
+      val chunkSize = ceil((range.last - range.head) / divideBy.toDouble).toInt
+
+      (0 until divideBy) map { i =>
+        if (i != divideBy - 1)
+          (chunkSize * i + range.head) to (chunkSize * i + range.head + chunkSize - 1)
+        else
+          (chunkSize * i + range.head) to range.last
+      }
+    }
+
+    def apply(numbers: Range, numChild: Int): Behavior[Result] = {
+      Behaviors.setup { ctx =>
+        val children = (1 to numChild) map { x =>
+          ctx.spawn(PrimeNumberJudgeActor(), s"child-actor-$x")
+        }
+
+        val ranges = splitRange(numbers, numChild)
+
+        children.zip(ranges) foreach { case (child, range) =>
+          child ! Task(range, ctx.self)
+        }
+
+        run(ctx, numChild, 0, 0)
+      }
+    }
+
+    private def run(
+        context: ActorContext[Result],
+        numChild: Int,
+        count: Int,
+        acc: Int
+    ): Behavior[Result] = {
+      Behaviors.receiveMessage { msg =>
+        if (count == numChild - 1) {
+          context.log.info(s"Result: ${acc + msg.countPrimeNumber}")
+          Behaviors.same
+        } else
+          MainActor.run(
+            context,
+            numChild,
+            count + 1,
+            acc + msg.countPrimeNumber
+          )
+      }
+    }
+  }
+
+  object PrimeNumberJudgeActor {
+    private def isPrime(n: Int): Boolean =
+      if (n < 2) false else !((2 until n - 1) exists (n % _ == 0))
+
+    def apply(): Behavior[Task] =
+      Behaviors.receive { (ctx, msg) =>
+        val result = (msg.numbers map { number =>
+          if (isPrime(number)) 1 else 0
+        }).sum
+
+        ctx.log.info(s"${ctx.self.path.name}: $result")
+
+        msg.sender ! Result(result)
+
+        Behaviors.same
+      }
+  }
+
+  def PrimeNumberSearch(): Unit = {
+    val _ = ActorSystem(MainActor(1010000 to 1040000, 4), "main-actor")
+  }
+}

--- a/concurrent/src/main/scala/chapter09/ShokyuAndChukyu.scala
+++ b/concurrent/src/main/scala/chapter09/ShokyuAndChukyu.scala
@@ -1,0 +1,42 @@
+package com.github.trackiss
+package chapter09
+
+import akka.actor.typed.{ActorSystem, Behavior, SupervisorStrategy}
+import akka.actor.typed.scaladsl.Behaviors
+
+object ShokyuAndChukyu {
+  object ParentActor {
+    def apply(): Behavior[(Int, Int)] =
+      Behaviors
+        .supervise[(Int, Int)] {
+          Behaviors.setup { ctx =>
+            val child = ctx.spawn(ChildActor(), "child-actor")
+
+            Behaviors.receiveMessage { numPair =>
+              child ! numPair
+              ctx.log.info(child.toString)
+              Behaviors.same
+            }
+          }
+        }
+        .onFailure(SupervisorStrategy.resume)
+  }
+
+  object ChildActor {
+    def apply(): Behavior[(Int, Int)] =
+      Behaviors.receive { (ctx, numPair) =>
+        ctx.log.info(
+          s"${numPair._1} / ${numPair._2} = ${numPair._1 / numPair._2}"
+        )
+        Behaviors.same
+      }
+  }
+
+  def MustResume(): Unit = {
+    val system = ActorSystem(ParentActor(), "parent-actor")
+
+    system ! (10, 5)
+    system ! (10, 0)
+    system ! (10, 5)
+  }
+}


### PR DESCRIPTION
## やったこと

### 初級

例外発生時に絶対に resume するアクターを作る

- 作れてないです
    - なぜか子アクターが死んだまま戻ってこない...
    - めちゃくちゃ調べたけどうまく行かなかったので白旗
        - typed じゃない actor では普通に書けたので、まぁよしとする

### 中級

子アクターが突然死したときの表示を見てみよう

- typed actor にはそもそも PoisonPill がない
    - 初級のコードを動かすと目的のエラーが発生するので、まぁよしとする

### 上級

複数の子アクターに素数を探し出してもらう

- それっぽい資料が見当たらなくて泣いてた
    - 悲しかったので Qiita かどこかに吐き出そうかな

## 学んだこと

- 「状態を引き回したい かつ 子アクターを生成したい」という状況でうまく動かせるコードが調べてもなかなか出てこなかった...
    - たとえば:

次のようにして、ステートレスなまま (見かけ上は) 状態を持つことができる:

```scala
object MyActor {
  def apply(countGreet: Int = 0): Behavior[String] =
    Behaviors.receive { (ctx, msg) =>
      ctx.log.info(msg)

      if (msg == "Hello")
        MyActor(counrGreet + 1)
      else
        Behaviors.same
    }
}

object Main extends App {
  val system = ActorSystem(MyActor(), "my-actor")

  system ! "foo"
  system ! "Hello"
}
```

また、次のようにして子アクターを生成することができる (classic actor では actorOf で外側から差し込むことができたが、typed actor ではできない):

```scala
object ParentActor {
  def apply(): Behavior[Unit] =
    Behaviors.setup { ctx =>
      val child = ctx.spawn(ChildActor(), "child-actor")

      Behaviors.receiveMessage { _ =>
        child ! "yeah"
      }
    }
}

object ChildActor {
  def apply(): Behavior[String] =
    Behaviors.receive { (ctx, msg) =>
      ctx.log.info(msg)
      Behaviors.same
    }
}

object Main extends App {
  val system = ActorSystem(ParentActor(), "parent-actor")

  system ! ()
}
```

しかし、その両方を実現しようとすると...:

```scala
object ParentActor {
  def apply(countReceive: Int = 0): Behavior[Unit] =
    Behaviors.setup { ctx =>
      val child = ctx.spawn(ChildActor(), "child-actor")

      Behaviors.receiveMessage { _ =>
        child ! "yeah"
        ParentActor(countReceive + 1)
      }
    }
}

object ChildActor {
  def apply(): Behavior[String] =
    Behaviors.receive { (ctx, msg) =>
      ctx.log.info(msg)
      Behaviors.same
    }
}

object Main extends App {
  val system = ActorSystem(ParentActor(), "parent-actor")

  system ! ()
}
```

...状態を更新しようと apply を呼び出したとたん、`val child = ctx.spawn(ChildActor(), "child-actor")` が再度実行され、「"child-actor" という名前はユニークでないよ」という旨のエラーが表示されてしまう。

ということで、上級でやっているように apply を分離させてやればいい。context は引数で渡す:

```scala
object ParentActor {
  def apply(): Behavior[Unit] = {
    Behaviors.setup { ctx =>
      val child = ctx.spawn(ChildActor(), "child-actor")
    }

    run(ctx, 0)
  }

  private def run(context: ActorContext[Unit], countReceive: Int): Behavior[Unit] =
    Behaviors.receiveMessage { _ =>
      child ! "yeah"
      ParentActor.run(context, countReceive + 1)
    }
}

object ChildActor {
  def apply(): Behavior[String] =
    Behaviors.receive { (ctx, msg) =>
      ctx.log.info(msg)
      Behaviors.same
    }
}

object Main extends App {
  val system = ActorSystem(ParentActor(), "parent-actor")

  system ! ()
}
```

はい勝ち〜

- 絶対に var やミュータブルコレクションを使いたくないという謎のこだわりによって苦しめられている感ある
    - object-oriented style にして、アクターそのものは状態持つってことにしたほうが絶対に楽だし実用的
    - functional style で書けてしまうのが悪いんだ、僕は悪くない
- Range って to とか until の情報保持してるんだ
    - よく考えたら step もあるので当たり前といえば当たり前
- 上級の splitRange の実装がびみょい
    - たとえば `splitRange(1 to 10, 4)` をすると、`Seq(1 to 3, 4 to 6, 7 to 9, 10 to 10)` とかになる
        - 分散させたいなら `Seq(1 to 3, 4 to 6, 7 to 8, 9 to 10)` とかになってくれると嬉しいよね
        - しかし良いアルゴリズムが思いつかなんだ

## 所感？

typed actor むずかしい