### PR TITLE
並行処理10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 lazy val akkaActorV = "2.6.14"
 lazy val logbackV = "1.2.3"
 lazy val mockitoV = "3.9.0"
+lazy val okHttpV = "4.9.1"
 lazy val parserCombinatorsV = "1.1.2"
 lazy val scalaTestV = "3.2.8"
 
@@ -62,7 +63,8 @@ lazy val concurrent = (project in file("concurrent"))
     name := "concurrent",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor-typed" % akkaActorV,
-      "ch.qos.logback" % "logback-classic" % logbackV
+      "ch.qos.logback" % "logback-classic" % logbackV,
+      "com.squareup.okhttp3" % "okhttp" % okHttpV
     ),
     version := "0.0.1"
   )

--- a/concurrent/src/main/scala/chapter10/Config.scala
+++ b/concurrent/src/main/scala/chapter10/Config.scala
@@ -1,0 +1,9 @@
+package com.github.trackiss
+package chapter10
+
+final case class Config(
+    wordsFilePath: String,
+    urlsFilePath: String,
+    outputDirPath: String,
+    numOfDownloader: Int
+)

--- a/concurrent/src/main/scala/chapter10/ImageFileDownloader.scala
+++ b/concurrent/src/main/scala/chapter10/ImageFileDownloader.scala
@@ -1,0 +1,88 @@
+package com.github.trackiss
+package chapter10
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import okhttp3._
+
+import java.io.{File, IOException}
+import java.nio.file.{Files, Paths, StandardOpenOption}
+import scala.util.{Failure, Success, Try}
+
+final class DownloadFailException extends IOException
+
+object ImageFileDownloader {
+  val jpegMediaType: MediaType = MediaType.parse("image/jpeg")
+
+  def apply(
+      config: Config,
+      client: OkHttpClient,
+      wnidWordMap: Map[String, String]
+  ): Behavior[Message] = {
+
+    Behaviors.receive { (ctx, msg) =>
+      msg match {
+        case imageNetUrl: ImageNetUrl =>
+          val request = new Request.Builder().url(imageNetUrl.url).build()
+
+          client
+            .newCall(request)
+            .enqueue(new Callback {
+              override def onFailure(call: Call, e: IOException): Unit =
+                imageNetUrl.sender ! DownloadFailure(e, imageNetUrl, ctx.self)
+
+              override def onResponse(call: Call, response: Response): Unit = {
+                if (
+                  response.isSuccessful && response
+                    .body()
+                    .contentType() == jpegMediaType
+                ) {
+                  val dir = new File(
+                    new File(config.outputDirPath),
+                    imageNetUrl.wnid + "-" + wnidWordMap(imageNetUrl.wnid)
+                  )
+                  dir.mkdir()
+
+                  val downloadFile = new File(dir, imageNetUrl.id + ".jpg")
+
+                  if (!downloadFile.exists()) downloadFile.createNewFile()
+
+                  val tmpFilePath = Paths.get(downloadFile.getAbsolutePath)
+
+                  Try {
+                    Files.write(
+                      tmpFilePath,
+                      response.body().bytes(),
+                      StandardOpenOption.WRITE
+                    )
+                  } match {
+                    case Success(_) =>
+                      imageNetUrl.sender ! DownloadSuccess(
+                        downloadFile.getAbsolutePath,
+                        imageNetUrl,
+                        ctx.self
+                      )
+                    case Failure(e) =>
+                      downloadFile.delete()
+                      imageNetUrl.sender ! DownloadFailure(
+                        e,
+                        imageNetUrl,
+                        ctx.self
+                      )
+                  }
+                } else {
+                  imageNetUrl.sender ! DownloadFailure(
+                    new DownloadFailException,
+                    imageNetUrl,
+                    ctx.self
+                  )
+                }
+                response.close()
+              }
+            })
+          Behaviors.same
+        case _ => Behaviors.same
+      }
+    }
+  }
+}

--- a/concurrent/src/main/scala/chapter10/Message.scala
+++ b/concurrent/src/main/scala/chapter10/Message.scala
@@ -1,0 +1,38 @@
+package com.github.trackiss
+package chapter10
+
+import akka.actor.typed.ActorRef
+
+abstract class Message(val sender: ActorRef[Message])
+
+sealed abstract class SupervisorMessage(sender: ActorRef[Message])
+    extends Message(sender)
+case class Start(override val sender: ActorRef[Message])
+    extends SupervisorMessage(sender)
+case class Finished(override val sender: ActorRef[Message])
+    extends SupervisorMessage(sender)
+case class DownloadSuccess(
+    tmpFilePath: String,
+    imageNetUrl: ImageNetUrl,
+    override val sender: ActorRef[Message]
+) extends SupervisorMessage(sender)
+case class DownloadFailure(
+    e: Throwable,
+    imageNetUrl: ImageNetUrl,
+    override val sender: ActorRef[Message]
+) extends SupervisorMessage(sender)
+
+sealed abstract class UrlsFileLoaderMessage(sender: ActorRef[Message])
+    extends Message(sender)
+case class LoadUrlsFile(override val sender: ActorRef[Message])
+    extends UrlsFileLoaderMessage(sender)
+
+sealed abstract class ImageFileDownloaderMessage(sender: ActorRef[Message])
+    extends Message(sender)
+
+case class ImageNetUrl(
+    id: String,
+    url: String,
+    wnid: String,
+    override val sender: ActorRef[Message]
+) extends ImageFileDownloaderMessage(sender)

--- a/concurrent/src/main/scala/chapter10/ShokyuAndChukyuAndJokyu.scala
+++ b/concurrent/src/main/scala/chapter10/ShokyuAndChukyuAndJokyu.scala
@@ -1,0 +1,24 @@
+package com.github.trackiss
+package chapter10
+
+import akka.actor.typed.ActorSystem
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object ShokyuAndChukyuAndJokyu {
+  def main(): Unit = {
+    val wordsFilePath = "/path/to/words.txt"
+    val urlsFilePath = "/path/to/fall11_urls.txt"
+    val outputDirPath = "/path/to/output"
+    val numOfDownloader = 2000
+
+    val config =
+      Config(wordsFilePath, urlsFilePath, outputDirPath, numOfDownloader)
+
+    val system = ActorSystem(Supervisor(config), "image-downloader-actor")
+    system ! Start(system)
+
+    Await.ready(system.whenTerminated, Duration.Inf)
+  }
+}

--- a/concurrent/src/main/scala/chapter10/Supervisor.scala
+++ b/concurrent/src/main/scala/chapter10/Supervisor.scala
@@ -1,0 +1,124 @@
+package com.github.trackiss
+package chapter10
+
+import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors, Routers}
+import okhttp3.OkHttpClient
+
+import java.util.concurrent.TimeUnit
+import scala.io.Source
+
+object Supervisor {
+  def apply(config: Config): Behavior[Message] = {
+    val wordsFileSource = Source.fromFile(config.wordsFilePath)
+    val wnidWordMap = wordsFileSource
+      .getLines()
+      .map(s => {
+        val strs = s.split("\t")
+        (strs.head, strs.tail.mkString("\t"))
+      })
+      .toMap
+
+    val client = new OkHttpClient.Builder()
+      .connectTimeout(1, TimeUnit.SECONDS)
+      .writeTimeout(1, TimeUnit.SECONDS)
+      .readTimeout(1, TimeUnit.SECONDS)
+      .build()
+
+    Behaviors.setup { ctx =>
+      val urlsFileLoader =
+        ctx.spawn(UrlsFileLoader(config), "urls-loader-actor")
+
+      val pool =
+        Routers
+          .pool(config.numOfDownloader)(
+            Behaviors
+              .supervise(ImageFileDownloader(config, client, wnidWordMap))
+              .onFailure(SupervisorStrategy.restart)
+          )
+          .withRoundRobinRouting()
+
+      val router = ctx.spawn(pool, "downloader-actors")
+      run(ctx, urlsFileLoader, router, config, 0, 0, 0, wnidWordMap)
+    }
+  }
+
+  private def run(
+      context: ActorContext[Message],
+      urlFileLoader: ActorRef[Message],
+      router: ActorRef[Message],
+      config: Config,
+      successCount: Int,
+      failureCount: Int,
+      fileLoadedUrlCount: Int,
+      wnidWordWrap: Map[String, String]
+  ): Behavior[Message] =
+    Behaviors.receiveMessage {
+      case Start(_) =>
+        urlFileLoader ! LoadUrlsFile(context.self)
+        Behaviors.same
+      case imageNetUrl: ImageNetUrl =>
+        router ! imageNetUrl.copy(sender = context.self)
+        run(
+          context,
+          urlFileLoader,
+          router,
+          config,
+          successCount,
+          failureCount,
+          fileLoadedUrlCount + 1,
+          wnidWordWrap
+        )
+      case DownloadSuccess(_, _, sender) =>
+        printConsoleAndCheckFinish(
+          context,
+          sender,
+          successCount + 1,
+          failureCount,
+          fileLoadedUrlCount
+        )
+        run(
+          context,
+          urlFileLoader,
+          router,
+          config,
+          successCount + 1,
+          failureCount,
+          fileLoadedUrlCount,
+          wnidWordWrap
+        )
+      case DownloadFailure(_, _, sender) =>
+        printConsoleAndCheckFinish(
+          context,
+          sender,
+          successCount,
+          failureCount + 1,
+          fileLoadedUrlCount
+        )
+        run(
+          context,
+          urlFileLoader,
+          router,
+          config,
+          successCount,
+          failureCount + 1,
+          fileLoadedUrlCount,
+          wnidWordWrap
+        )
+      case _ => Behaviors.same
+    }
+
+  private def printConsoleAndCheckFinish(
+      context: ActorContext[Message],
+      sender: ActorRef[Message],
+      successCount: Int,
+      failureCount: Int,
+      fileLoadedUrlCount: Int
+  ): Unit = {
+    val total = successCount + failureCount
+    println(
+      s"total: $total, successCount: $successCount, failureCount: $failureCount"
+    )
+    if (total == fileLoadedUrlCount) sender ! Finished(context.self)
+  }
+}

--- a/concurrent/src/main/scala/chapter10/Supervisor.scala
+++ b/concurrent/src/main/scala/chapter10/Supervisor.scala
@@ -1,7 +1,12 @@
 package com.github.trackiss
 package chapter10
 
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.{
+  ActorRef,
+  Behavior,
+  MailboxSelector,
+  SupervisorStrategy
+}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, Routers}
 import okhttp3.OkHttpClient
 
@@ -38,7 +43,8 @@ object Supervisor {
           )
           .withRoundRobinRouting()
 
-      val router = ctx.spawn(pool, "downloader-actors")
+      val router =
+        ctx.spawn(pool, "downloader-actors", MailboxSelector.bounded(10))
       run(ctx, urlsFileLoader, router, config, 0, 0, 0, wnidWordMap)
     }
   }

--- a/concurrent/src/main/scala/chapter10/UrlsFileLoader.scala
+++ b/concurrent/src/main/scala/chapter10/UrlsFileLoader.scala
@@ -1,0 +1,28 @@
+package com.github.trackiss
+package chapter10
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+
+import scala.io.{Codec, Source}
+
+object UrlsFileLoader {
+  def apply(config: Config): Behavior[Message] =
+    Behaviors.receive { (ctx, msg) =>
+      msg match {
+        case LoadUrlsFile(sender) =>
+          val urlsFileSource = Source.fromFile(config.urlsFilePath)(Codec.UTF8)
+          val urlIterator = urlsFileSource.getLines()
+          urlIterator foreach { line =>
+            val strs = line.split("\t")
+            val id = strs.head
+            val url = strs.tail.mkString("\t")
+            val wnid = id.split("_").head
+            sender ! ImageNetUrl(id, url, wnid, ctx.self)
+          }
+          urlsFileSource.close()
+          Behaviors.same
+        case _ => Behaviors.same
+      }
+    }
+}


### PR DESCRIPTION
## やったこと

ImageNet が死んでいたため、実際の動作は確認していません。  
ただ、なにもしないというのも気に食わなかったので typed actor で全部書き直しました。ビルドは通っているので満足することにします。

### 初級

画像ダウンローダーの動きを VisualVM で眺めよう

- やってないです

### 中級

typesafe-config による制御

- typed actor だと色々と勝手が違っているっぽかったので、直接コードいじってます

### 上級

akka-stream によるメッセージキューの再実装

- ギブアップ。また時間のあるときにやってみたい

## 学んだこと

- akka のディスパッチ関連の処理はどうやってアクターに適用させるんだろう
    - classic actor だとトレイトを継承するだけでいいっぽいけど、typed actor だとそうはならなさそう
    - 要調査
- ほぼ写経したため、あんまり typed の恩恵を受けられない実装になってしまったことが悔やまれる